### PR TITLE
feat: added filters for Schedules module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ next-env.d.ts
 
 # vscode
 .vscode/*
+
+# prettier
+.prettierrc

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "clean",
+    "name": "usc-days",
     "version": "0.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "clean",
+            "name": "usc-days",
             "version": "0.1.0",
             "dependencies": {
                 "@hookform/resolvers": "^5.2.2",

--- a/src/components/schedules/schedule-filter.tsx
+++ b/src/components/schedules/schedule-filter.tsx
@@ -7,14 +7,14 @@ interface SportSelectorProps {
     selected: number | null;
 }
 
-export default function DayNavigation({
+export default function ScheduleFilter({
     onSelect,
     selected,
 }: SportSelectorProps) {
     return (
         <div className="sticky top-16 z-40 flex flex-col bg-white">
             <div className="flex flex-col gap-4 w-full px-4 py-8 sm:max-w-5xl mx-auto relative">
-                <div className="flex flex-col md:flex-row justify-between">
+                {/* <div className="flex flex-col md:flex-row justify-between">
                     <div className="flex flex-col">
                         <h2
                             className="text-2xl md:text-4xl font-semibold uppercase"
@@ -78,7 +78,7 @@ export default function DayNavigation({
                             </button>
                         </div>
                     </div>
-                </div>
+                </div> */}
                 <SportSelector onSelect={onSelect} selected={selected} />
             </div>
         </div>

--- a/src/components/schedules/schedules.tsx
+++ b/src/components/schedules/schedules.tsx
@@ -5,7 +5,7 @@ import SchedulesList from "@/src/components/schedules/schedules-list"; // cards 
 import axios from "axios";
 import { Schedules } from "@/src/types/types";
 import AddScheduleDialog from "./add-schedule-dialog";
-import DayNavigation from "./day-navigation";
+import ScheduleFilter from "./schedule-filter";
 import { useInitializeUserStore, useUserStore } from "@/src/stores/user-store";
 import SchedulesListSkeleton from "./schedules-list-skeleton";
 
@@ -47,7 +47,7 @@ export default function SchedulesPage() {
 
   return (
     <>
-      <DayNavigation onSelect={setSelectedSport} selected={selectedSport} />
+      <ScheduleFilter onSelect={setSelectedSport} selected={selectedSport} />
       <div className="p-4 sm:py-10 sm:max-w-5xl mx-auto relative">
         <div className="flex flex-col gap-4">
           {email && (


### PR DESCRIPTION
This pull request refactors the schedule filter component for improved clarity and maintainability. The main change is renaming the component from `DayNavigation` to `ScheduleFilter`, updating its usage throughout the codebase, and commenting out some unused markup for future cleanup.

Component refactoring:

* Renamed the file and component from `day-navigation.tsx`/`DayNavigation` to `schedule-filter.tsx`/`ScheduleFilter`, and updated all references to use the new name. [[1]](diffhunk://#diff-19f96e7b4daa45a75776c0496426c135ed9d2a0577369e705fc42380d7653bd0L10-R17) [[2]](diffhunk://#diff-f8ef9083dbd4dcf89826058c9e9478e168605dd0c4e813775c9fbe15ac3cb28eL8-R8) [[3]](diffhunk://#diff-f8ef9083dbd4dcf89826058c9e9478e168605dd0c4e813775c9fbe15ac3cb28eL50-R50)
* Commented out unused markup within the `ScheduleFilter` component to simplify the UI and prepare for future cleanup.