### PR TITLE
feat: queries and API route for merchandise categories

### DIFF
--- a/app/api/categories/route.ts
+++ b/app/api/categories/route.ts
@@ -1,0 +1,118 @@
+import CategoryService from "@/src/services/category.service";
+import { NextRequest, NextResponse } from "next/server";
+import {
+  AddMerchCategorySchema,
+  DeleteMerchCategorySchema,
+  EditMerchCategorySchema,
+} from "@/src/types/merchCategories.types";
+
+const categoryService = new CategoryService();
+
+export async function GET(req: NextRequest) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const categoryId = searchParams.get("categoryId");
+
+    if (!categoryId) {
+      const categories = await categoryService.getCategories();
+      return NextResponse.json(
+        { categories, count: categories.length },
+        { status: 200 },
+      );
+    } else {
+      const category = await categoryService.getCategoryById(categoryId);
+      return NextResponse.json({ category }, { status: 200 });
+    }
+  } catch (error) {
+    console.log("Error in fetching merch categories: ", error);
+    return NextResponse.json(
+      {
+        error: "An unexpected error occured while fetching merch categories",
+      },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const result = AddMerchCategorySchema.safeParse(body);
+
+    if (!result.success) {
+      return NextResponse.json(
+        { error: `Category validation error: ${result.error}` },
+        { status: 400 },
+      );
+    }
+
+    const validatedBody = result.data;
+    const newCategory = await categoryService.addCategory(validatedBody);
+    return NextResponse.json({ newCategory }, { status: 201 });
+  } catch (error) {
+    console.error("Error adding category: ", error);
+    return NextResponse.json(
+      {
+        error: "An unexpected error occurred while adding the category.",
+      },
+      { status: 500 },
+    );
+  }
+}
+
+export async function PUT(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const result = EditMerchCategorySchema.safeParse(body);
+
+    if (!result.success) {
+      return NextResponse.json(
+        { error: `Category validation error: ${result.error}` },
+        { status: 400 },
+      );
+    }
+
+    const validatedBody = result.data;
+    const updatedCategory = await categoryService.editCategory(
+      String(validatedBody.id),
+      validatedBody,
+    );
+
+    return NextResponse.json({ updatedCategory }, { status: 200 });
+  } catch (error) {
+    console.error("Error editing category: ", error);
+    return NextResponse.json(
+      {
+        error: "An unexpected error occurred while editing the category.",
+      },
+      { status: 500 },
+    );
+  }
+}
+
+export async function DELETE(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const result = DeleteMerchCategorySchema.safeParse(body);
+
+    if (!result.success) {
+      return NextResponse.json(
+        { error: `Category validation error: ${result.error}` },
+        { status: 400 },
+      );
+    }
+
+    const validatedBody = result.data;
+    const deletedCategory = await categoryService.deleteCategory(validatedBody);
+
+    return NextResponse.json({ deletedCategory }, { status: 200 });
+  } catch (error) {
+    console.error("Error deleting category: ", error);
+    return NextResponse.json(
+      {
+        error: "An unexpected error occurred while deleting category.",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/queries/categories.queries.ts
+++ b/src/queries/categories.queries.ts
@@ -1,0 +1,97 @@
+"use client";
+
+import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query";
+import {
+  AddMerchCategoryPayload,
+  EditMerchCategoryPayload,
+  DeleteMerchCategoryPayload,
+} from "../types/merchCategories.types";
+import axios from "axios";
+import { MerchandiseCategory } from "../lib/prisma/generated/client";
+
+const STALE_TIME = 1000 * 60 * 5;
+
+export const getCategoriesQuery = () => {
+  return useQuery<MerchandiseCategory[]>({
+    queryKey: ["categories"],
+    queryFn: async () => {
+      const response = await axios.get("/api/categories");
+      return response.data.categories;
+    },
+    staleTime: STALE_TIME,
+  });
+};
+
+export const getCategoryQuery = (categoryId?: number) => {
+  return useQuery<MerchandiseCategory>({
+    queryKey: ["categories", categoryId],
+    queryFn: async () => {
+      const response = await axios.get(`/api/categories?categoryId`, {
+        params: { categoryId },
+      });
+      return response.data.category;
+    },
+    staleTime: STALE_TIME,
+    enabled: !!categoryId,
+  });
+};
+
+export const useAddCategoriesQuery = () => {
+  const queryClient = useQueryClient();
+  return useMutation<
+    MerchandiseCategory,
+    Error,
+    AddMerchCategoryPayload,
+    { prevCategories?: MerchandiseCategory[] }
+  >({
+    mutationFn: async (data) => {
+      const response = await axios.post("/api/categories", data);
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["categories"] });
+    },
+    onError: (err, g, context: any) => {
+      if (context?.prevCategories) {
+        queryClient.setQueryData(["categories"], context.prevCategories);
+      }
+    },
+  });
+};
+
+export const useEditCategoriesQuery = () => {
+  const queryClient = useQueryClient();
+  return useMutation<MerchandiseCategory, Error, EditMerchCategoryPayload>({
+    mutationFn: async (catData) => {
+      const { id, ...rest } = catData;
+      const { data } = await axios.put("/api/categories", { id, ...rest });
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["categories"] });
+    },
+    onError: (err, g, context: any) => {
+      if (context?.prevCategories) {
+        queryClient.setQueryData(["categories"], context.prevCategories);
+      }
+    },
+  });
+};
+
+export const useDeleteCategoriesQuery = () => {
+  const queryClient = useQueryClient();
+  return useMutation<MerchandiseCategory, Error, DeleteMerchCategoryPayload>({
+    mutationFn: async (catData) => {
+      const { data } = await axios.delete("/api/categories", { data: catData });
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["categories"] });
+    },
+    onError: (err, g, context: any) => {
+      if (context?.prevCategories) {
+        queryClient.setQueryData(["categories"], context.prevCategories);
+      }
+    },
+  });
+};

--- a/src/queries/champions.queries.ts
+++ b/src/queries/champions.queries.ts
@@ -3,69 +3,73 @@
 import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query";
 import axios from "axios";
 import { Champions } from "@/src/types/types";
-import { AddChampionPayload, DeleteChampionPayload, EditChampionPayload } from "../types/champions.types";
+import {
+  AddChampionPayload,
+  DeleteChampionPayload,
+  EditChampionPayload,
+} from "../types/champions.types";
 
 const STALE_TIME = 1000 * 60 * 5;
 
 export const getChampionsQuery = () =>
-    useQuery<Champions[]>({
-        queryKey: ["champions"],
-        queryFn: async () => {
-            const response = await axios.get("/api/champions");
-            return response.data.champions;
-        },
-        staleTime: STALE_TIME,
-    });
+  useQuery<Champions[]>({
+    queryKey: ["champions"],
+    queryFn: async () => {
+      const response = await axios.get("/api/champions");
+      return response.data.champions;
+    },
+    staleTime: STALE_TIME,
+  });
 
 export const useAddChampionsQuery = () => {
-    const queryClient = useQueryClient();
-    return useMutation<any, Error, AddChampionPayload>({
-        mutationFn: async (data) => {
-            const response = await axios.post(`/api/champions`, data);
-            return response.data;
-        },
-        onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: ["champions"] });
-        },
-        onError: (err, c, context: any) => {
-            if (context?.prevChampions) {
-                queryClient.setQueryData(["champions"], context.prevChampions);
-            }
-        },
-    });
+  const queryClient = useQueryClient();
+  return useMutation<Champions, Error, AddChampionPayload>({
+    mutationFn: async (data) => {
+      const response = await axios.post(`/api/champions`, data);
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["champions"] });
+    },
+    onError: (err, c, context: any) => {
+      if (context?.prevChampions) {
+        queryClient.setQueryData(["champions"], context.prevChampions);
+      }
+    },
+  });
 };
 
 export const useEditChampionsQuery = () => {
-    const queryClient = useQueryClient();
-    return useMutation<any, Error, EditChampionPayload>({
-        mutationFn: async (data) => {
-            const response = await axios.put(`/api/champions`, data);
-            return response.data;
-        },
-        onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: ["champions"] });
-        },
+  const queryClient = useQueryClient();
+  return useMutation<Champions, Error, EditChampionPayload>({
+    mutationFn: async (data) => {
+      const response = await axios.put(`/api/champions`, data);
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["champions"] });
+    },
 
-        onError: (error) => {
-            console.error("Error editing champion: ", error);
-        },
-    });
+    onError: (error) => {
+      console.error("Error editing champion: ", error);
+    },
+  });
 };
 
 export const useDeleteChampionsQuery = () => {
-    const queryClient = useQueryClient();
-    return useMutation<any, Error, DeleteChampionPayload>({
-        mutationFn: async ({ id }) => {
-            const { data } = await axios.delete(`/api/champions`, {
-                data: { id }
-            });
-            return data;
-        },
-        onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: ["champions"] });
-        },
-        onError: (error) => {
-            console.error("Error deleting champion: ", error);
-        }
-    });
+  const queryClient = useQueryClient();
+  return useMutation<Champions, Error, DeleteChampionPayload>({
+    mutationFn: async ({ id }) => {
+      const { data } = await axios.delete(`/api/champions`, {
+        data: { id },
+      });
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["champions"] });
+    },
+    onError: (error) => {
+      console.error("Error deleting champion: ", error);
+    },
+  });
 };

--- a/src/queries/games.queries.ts
+++ b/src/queries/games.queries.ts
@@ -2,76 +2,80 @@
 
 import { AddGamePayload, EditGamePayload } from "@/src/types/games.types";
 import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query";
+import { Game } from "../lib/prisma/generated/client";
 import axios from "axios";
 const STALE_TIME = 1000 * 60 * 5;
 
-export const getGamesQuery = (params?: { startDate?: string; endDate?: string }) =>
-    useQuery<any>({
-        queryKey: ["games", params],
-        queryFn: async () => {
-            const queryParams = new URLSearchParams();
-            if (params?.startDate) queryParams.append("startDate", params.startDate);
-            if (params?.endDate) queryParams.append("endDate", params.endDate);
-            
-            const url = `/api/games${queryParams.toString() ? `?${queryParams.toString()}` : ""}`;
-            const response = await axios.get(url);
-            return response.data.games;
-        },
-        staleTime: STALE_TIME,
-    });
+export const getGamesQuery = (params?: {
+  startDate?: string;
+  endDate?: string;
+}) =>
+  useQuery<Game[]>({
+    queryKey: ["games", params],
+    queryFn: async () => {
+      const queryParams = new URLSearchParams();
+      if (params?.startDate) queryParams.append("startDate", params.startDate);
+      if (params?.endDate) queryParams.append("endDate", params.endDate);
+
+      const url = `/api/games${queryParams.toString() ? `?${queryParams.toString()}` : ""}`;
+      const response = await axios.get(url);
+      return response.data.games;
+    },
+    staleTime: STALE_TIME,
+  });
 
 export const useAddGamesQuery = () => {
-    const queryClient = useQueryClient();
-    return useMutation<any, Error, AddGamePayload, { prevGames?: any[] }>({
-        mutationFn: async (data) => {
-            const response = await axios.post(`/api/games`, data);
-            return response.data;
-        },
-        onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: ["games"] });
-        },
-        onError: (err, g, context: any) => {
-            if (context?.prevGames) {
-                queryClient.setQueryData(["games"], context.prevGames);
-            }
-        },
-    });
+  const queryClient = useQueryClient();
+  return useMutation<Game, Error, AddGamePayload, { prevGames?: any[] }>({
+    mutationFn: async (data) => {
+      const response = await axios.post(`/api/games`, data);
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["games"] });
+    },
+    onError: (err, g, context: any) => {
+      if (context?.prevGames) {
+        queryClient.setQueryData(["games"], context.prevGames);
+      }
+    },
+  });
 };
 
 export const useEditGamesQuery = () => {
-    const queryClient = useQueryClient();
-    return useMutation<any, Error, EditGamePayload>({
-        mutationFn: async (gameData) => {
-            const { id, ...rest } = gameData;
-            const { data } = await axios.put("/api/games", { id, ...rest });
-            return data;
-        },
+  const queryClient = useQueryClient();
+  return useMutation<Game, Error, EditGamePayload>({
+    mutationFn: async (gameData) => {
+      const { id, ...rest } = gameData;
+      const { data } = await axios.put("/api/games", { id, ...rest });
+      return data;
+    },
 
-        onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: ["games"] });
-        },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["games"] });
+    },
 
-        onError: (error) => {
-            console.error("Error editing game: ", error);
-        },
-    });
+    onError: (error) => {
+      console.error("Error editing game: ", error);
+    },
+  });
 };
 
 export const useDeleteGamesQuery = () => {
-    const queryClient = useQueryClient();
+  const queryClient = useQueryClient();
 
-    return useMutation<any, Error, { scheduleId: number }>({
-        mutationFn: async ({ scheduleId }) => {
-            const { data } = await axios.delete(`/api/games`, {
-                data: { id: scheduleId },
-            });
-            return data;
-        },
-        onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: ["games"] });
-        },
-        onError: (error) => {
-            console.error("Error deleting game:", error);
-        },
-    });
+  return useMutation<Game, Error, { scheduleId: number }>({
+    mutationFn: async ({ scheduleId }) => {
+      const { data } = await axios.delete(`/api/games`, {
+        data: { id: scheduleId },
+      });
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["games"] });
+    },
+    onError: (error) => {
+      console.error("Error deleting game:", error);
+    },
+  });
 };

--- a/src/queries/teams.queries.ts
+++ b/src/queries/teams.queries.ts
@@ -1,46 +1,47 @@
 import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query";
+import { AddTeamPayload } from "../types/teams.types";
 import axios from "axios";
 
 type Team = {
-    id: number;
-    teamName: string;
+  id: number;
+  teamName: string;
 };
 
 const STALE_TIME = 1000 * 60 * 5;
 
 export const getTeamsQuery = () =>
-    useQuery<Team[]>({
-        queryKey: ["teams"],
-        queryFn: async () => {
-            const response = await axios.get("/api/teams");
-            return response.data.teams;
-        },
-        staleTime: STALE_TIME,
-    });
+  useQuery<Team[]>({
+    queryKey: ["teams"],
+    queryFn: async () => {
+      const response = await axios.get("/api/teams");
+      return response.data.teams;
+    },
+    staleTime: STALE_TIME,
+  });
 
 export const addTeamsQuery = () => {
-    const queryClient = useQueryClient();
-    return useMutation<any>({
-        mutationFn: async (data) => {
-            const response = await axios.post(`/api/teams`, data);
-            return response.data;
-        },
-        onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: ["teams"] });
-        },
-        onMutate: async (t) => {
-            await queryClient.cancelQueries({ queryKey: ["teams"] });
-            const prevTeams = queryClient.getQueryData<any[]>(["teams"]);
-            if (prevTeams) {
-                queryClient.setQueryData(["teams"], [...prevTeams, t]);
-            }
+  const queryClient = useQueryClient();
+  return useMutation<Team, Error, AddTeamPayload>({
+    mutationFn: async (data) => {
+      const response = await axios.post(`/api/teams`, data);
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["teams"] });
+    },
+    onMutate: async (t) => {
+      await queryClient.cancelQueries({ queryKey: ["teams"] });
+      const prevTeams = queryClient.getQueryData<any[]>(["teams"]);
+      if (prevTeams) {
+        queryClient.setQueryData(["teams"], [...prevTeams, t]);
+      }
 
-            return { prevTeams };
-        },
-        onError: (err, t, context: any) => {
-            if (context?.prevTeams) {
-                queryClient.setQueryData(["teams"], context.prevTeams);
-            }
-        },
-    });
+      return { prevTeams };
+    },
+    onError: (err, t, context: any) => {
+      if (context?.prevTeams) {
+        queryClient.setQueryData(["teams"], context.prevTeams);
+      }
+    },
+  });
 };


### PR DESCRIPTION
- Created the API route `api/categories` for merchandise categories, where the GET route utilizes an optional `categoryId` parameter for individual category fetching
- Created TanStack Query hooks and mutations for merchandise categories
- Small improvements to other query modules (added types)
