### PR TITLE
fix: update GameCard to display scores based on winner instead of truthy/falsy value of scores

### DIFF
--- a/src/components/schedules/games-card.tsx
+++ b/src/components/schedules/games-card.tsx
@@ -56,7 +56,7 @@ export function GameCard({ game, onOpen }: ScheduleCardProps) {
                 height={24}
               />
             </div>
-            {Number(game.teamAScore) && Number(game.teamBScore) ? (
+            {game.winnerId ? (
               <div className="flex gap-2 justify-center">
                 <span
                   className={


### PR DESCRIPTION
This pull request updates the logic for displaying game scores in the `GameCard` component. Instead of checking if both teams have scores, the component now checks for the presence of a winner to determine if the score section should be rendered.

* Game display logic update:
  * Changed the conditional rendering in `GameCard` to use `game.winnerId` instead of checking if both `game.teamAScore` and `game.teamBScore` are numbers. (`src/components/schedules/games-card.tsx`, [src/components/schedules/games-card.tsxL59-R59](diffhunk://#diff-6b85510b71f65b339e6e7280dc9bf5e8113453b6a0236cbf7cb074b831fd3121L59-R59))