### PR TITLE
refactor: replace transformGamesToSchoolRank with transformSchoolsData and transformTeamsData for leaderboard calculations

### DIFF
--- a/src/components/leaderboards/leaderboards.tsx
+++ b/src/components/leaderboards/leaderboards.tsx
@@ -4,7 +4,7 @@ import { useMemo } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import { DataTable } from "@/src/components/leaderboards/data-table";
 import { columns } from "@/src/components/leaderboards/columns";
-import { transformGamesToSchoolRank } from "@/src/components/leaderboards/transformData";
+import { transformSchoolsData } from "@/src/components/leaderboards/transformSchoolsData";
 import { getGamesQuery } from "@/src/queries/games.queries";
 import SportSelector from "@/src/components/ui/sport-selector";
 import LeaderboardsTableSkeleton from "@/src/components/leaderboards/leaderboards-table-skeleton";
@@ -19,7 +19,7 @@ export default function Leaderboards() {
   const { data: games = [], error, isLoading: loading } = getGamesQuery();
 
   const transformed = useMemo(() => {
-    return transformGamesToSchoolRank(games, selectedSport || undefined);
+    return transformSchoolsData(games, selectedSport || undefined);
   }, [games, selectedSport]);
 
   const handleSportSelect = (sportId: number | null) => {

--- a/src/components/leaderboards/transformSchoolsData.tsx
+++ b/src/components/leaderboards/transformSchoolsData.tsx
@@ -1,13 +1,26 @@
 import { Schedules } from "@/src/types/types";
 import { StandingData } from "@/src/types/types";
+import { schoolLogos } from "@/src/constants/schoolLogos";
 
-export function transformGamesToSchoolRank(
+export function transformSchoolsData(
   games: Schedules[],
   sportId?: number,
 ): StandingData[] {
+  // Get school keys (e.g., SOE, SAFAD, etc.)
+  const schoolKeys = Object.keys(schoolLogos).filter((k) => k !== "Default");
+
+  // Helper to get school from team name
+  function getSchoolFromTeam(teamName: string): string | null {
+    if (!teamName) return null;
+    const match = schoolKeys.find((school) =>
+      teamName.toLowerCase().startsWith(school.toLowerCase()),
+    );
+    return match || null;
+  }
+
   const leaderboard: Record<
     string,
-    { team: string; wins: number; losses: number; sport: string }
+    { school: string; wins: number; losses: number; sport: string }
   > = {};
 
   // Filter by sport if specified
@@ -21,23 +34,27 @@ export function transformGamesToSchoolRank(
     const teamA = g.teamA.teamName;
     const teamB = g.teamB.teamName;
 
-    // Skip if team names are missing
-    if (!teamA || !teamB) continue;
+    // Map team names to schools
+    const schoolA = getSchoolFromTeam(teamA);
+    const schoolB = getSchoolFromTeam(teamB);
 
-    // Initialize Team A entry if it doesn't exist
-    if (!leaderboard[teamA]) {
-      leaderboard[teamA] = {
-        team: teamA,
+    // Omit if either team does not match a school
+    if (!schoolA || !schoolB) continue;
+
+    // Initialize School A entry if it doesn't exist
+    if (!leaderboard[schoolA]) {
+      leaderboard[schoolA] = {
+        school: schoolA,
         wins: 0,
         losses: 0,
         sport: sportId !== undefined ? sport : "Overall",
       };
     }
 
-    // Initialize Team B entry if it doesn't exist
-    if (!leaderboard[teamB]) {
-      leaderboard[teamB] = {
-        team: teamB,
+    // Initialize School B entry if it doesn't exist
+    if (!leaderboard[schoolB]) {
+      leaderboard[schoolB] = {
+        school: schoolB,
         wins: 0,
         losses: 0,
         sport: sportId !== undefined ? sport : "Overall",
@@ -46,8 +63,8 @@ export function transformGamesToSchoolRank(
 
     // Handle both teams forfeiting - both get a loss
     if (g.teamAForfeited && g.teamBForfeited) {
-      leaderboard[teamA].losses++;
-      leaderboard[teamB].losses++;
+      leaderboard[schoolA].losses++;
+      leaderboard[schoolB].losses++;
       continue;
     }
 
@@ -59,22 +76,22 @@ export function transformGamesToSchoolRank(
     // Skip if no winner is declared and no forfeits
     if (!g.winnerId) continue;
 
-    const winnerTeam =
+    const winnerSchool =
       g.winnerId === g.teamA.id
-        ? teamA
+        ? schoolA
         : g.winnerId === g.teamB.id
-          ? teamB
+          ? schoolB
           : null;
 
-    if (!winnerTeam) continue;
+    if (!winnerSchool) continue;
 
     // Update wins/losses
-    if (winnerTeam === teamA) {
-      leaderboard[teamA].wins++;
-      leaderboard[teamB].losses++;
+    if (winnerSchool === schoolA) {
+      leaderboard[schoolA].wins++;
+      leaderboard[schoolB].losses++;
     } else {
-      leaderboard[teamB].wins++;
-      leaderboard[teamA].losses++;
+      leaderboard[schoolB].wins++;
+      leaderboard[schoolA].losses++;
     }
   }
 
@@ -83,7 +100,7 @@ export function transformGamesToSchoolRank(
       const totalGames = entry.wins + entry.losses;
       return {
         id: idx + 1,
-        team: entry.team,
+        team: entry.school, // 'team' field now holds the school name
         wins: entry.wins,
         losses: entry.losses,
         winPercentage: totalGames > 0 ? (entry.wins / totalGames) * 100 : 0,

--- a/src/components/standings/standings.tsx
+++ b/src/components/standings/standings.tsx
@@ -15,12 +15,12 @@ import DataTable from "@/src/components/standings/standings-table";
 import StandingsTableSkeleton from "@/src/components/standings/standings-table-skeleton";
 import standingColumns from "@/src/components/standings/columns";
 import { GameType } from "@/src/lib/prisma/generated/client";
-import { transformGamesToSchoolRank } from "../leaderboards/transformData";
 import { Champions, Schedules, StandingData } from "@/src/types/types";
 import { useInitializeUserStore, useUserStore } from "@/src/stores/user-store";
 import { EditChampionPayload } from "@/src/types/champions.types";
 import StandingFormDialog from "./standing-dialog-form";
 import { toast } from "sonner";
+import { transformTeamsData } from "./transformTeamsData";
 
 export type StandingWithRank = StandingData & {
   rank: number;
@@ -121,7 +121,7 @@ export default function Standings() {
       );
 
       // Transform games to standings statistics
-      const gameStandings = transformGamesToSchoolRank(games, selectedSport);
+      const gameStandings = transformTeamsData(games, selectedSport);
 
       // Create comprehensive standings list
       const allStandings: StandingWithRank[] = [];
@@ -138,23 +138,23 @@ export default function Standings() {
       });
 
       // Add champions without game history
-      filteredChampions.forEach((champion) => {
-        const existingStanding = allStandings.find(
-          (s) => s.team === champion.team.teamName,
-        );
+      //   filteredChampions.forEach((champion) => {
+      //     const existingStanding = allStandings.find(
+      //       (s) => s.team === champion.team.teamName,
+      //     );
 
-        if (!existingStanding) {
-          allStandings.push({
-            id: champion.team.id,
-            team: champion.team.teamName,
-            wins: 0,
-            losses: 0,
-            winPercentage: 0,
-            sport: champion.gameType.gameName,
-            rank: champion.rank,
-          });
-        }
-      });
+      //     if (!existingStanding) {
+      //       allStandings.push({
+      //         id: champion.team.id,
+      //         team: champion.team.teamName,
+      //         wins: 0,
+      //         losses: 0,
+      //         winPercentage: 0,
+      //         sport: champion.gameType.gameName,
+      //         rank: champion.rank,
+      //       });
+      //     }
+      //   });
 
       return { data: allStandings, error: false };
     } catch (err) {
@@ -247,8 +247,6 @@ export default function Standings() {
     [championsData, selectedSport],
   );
 
-  
-
   const handleCloseDialog = useCallback(() => {
     setFormData(null);
     setShowDialog(false);
@@ -273,7 +271,6 @@ export default function Standings() {
             onValueChangeAction={handleSportSelect}
             className="flex items-center justify-between px-5.5! py-1.75! h-13.5! max-w-xs bg-white shadow-sm rounded-[2px] border border-neutral-200 border-l-2 transition-colors hover:border-l-tc_primary-500 data-[state=open]:border-l-tc_primary-500 outline-none [&>svg.size-4.opacity-50]:hidden"
           />
-          
         </div>
 
         {loading && selectedSport && (
@@ -291,7 +288,9 @@ export default function Standings() {
                 <Cards
                   key={`rank-${index + 1}`}
                   data={card}
-                  onSelect={() => isAdmin ? handleCardClick(index + 1) : undefined}
+                  onSelect={() =>
+                    isAdmin ? handleCardClick(index + 1) : undefined
+                  }
                 />
               ))}
             </div>

--- a/src/components/standings/transformTeamsData.ts
+++ b/src/components/standings/transformTeamsData.ts
@@ -1,0 +1,94 @@
+import { Schedules } from "@/src/types/types";
+import { StandingData } from "@/src/types/types";
+
+export function transformTeamsData(
+  games: Schedules[],
+  sportId?: number,
+): StandingData[] {
+  const leaderboard: Record<
+    string,
+    { team: string; wins: number; losses: number; sport: string }
+  > = {};
+
+  // Filter by sport if specified
+  const filteredGames =
+    sportId !== undefined
+      ? games.filter((g) => g.gameType.id === sportId)
+      : games;
+
+  for (const g of filteredGames) {
+    const sport = g.gameType.gameName;
+    const teamA = g.teamA.teamName;
+    const teamB = g.teamB.teamName;
+
+    // Skip if team names are missing
+    if (!teamA || !teamB) continue;
+
+    // Initialize Team A entry if it doesn't exist
+    if (!leaderboard[teamA]) {
+      leaderboard[teamA] = {
+        team: teamA,
+        wins: 0,
+        losses: 0,
+        sport: sportId !== undefined ? sport : "Overall",
+      };
+    }
+
+    // Initialize Team B entry if it doesn't exist
+    if (!leaderboard[teamB]) {
+      leaderboard[teamB] = {
+        team: teamB,
+        wins: 0,
+        losses: 0,
+        sport: sportId !== undefined ? sport : "Overall",
+      };
+    }
+
+    // Handle both teams forfeiting - both get a loss
+    if (g.teamAForfeited && g.teamBForfeited) {
+      leaderboard[teamA].losses++;
+      leaderboard[teamB].losses++;
+      continue;
+    }
+
+    // Skip draws - no wins or losses for either team
+    if (g.isDraw) {
+      continue;
+    }
+
+    // Skip if no winner is declared and no forfeits
+    if (!g.winnerId) continue;
+
+    const winnerTeam =
+      g.winnerId === g.teamA.id
+        ? teamA
+        : g.winnerId === g.teamB.id
+          ? teamB
+          : null;
+
+    if (!winnerTeam) continue;
+
+    // Update wins/losses
+    if (winnerTeam === teamA) {
+      leaderboard[teamA].wins++;
+      leaderboard[teamB].losses++;
+    } else {
+      leaderboard[teamB].wins++;
+      leaderboard[teamA].losses++;
+    }
+  }
+
+  return Object.values(leaderboard)
+    .map((entry, idx) => {
+      const totalGames = entry.wins + entry.losses;
+      return {
+        id: idx + 1,
+        team: entry.team,
+        wins: entry.wins,
+        losses: entry.losses,
+        winPercentage: totalGames > 0 ? (entry.wins / totalGames) * 100 : 0,
+        sport: entry.sport,
+      };
+    })
+    .sort((a, b) => b.winPercentage - a.winPercentage);
+}


### PR DESCRIPTION
This pull request refactors how leaderboard and standings data are transformed and displayed by introducing new utility functions and updating component imports and usage accordingly. The main focus is on improving clarity and separation of concerns between school-level and team-level data processing. The changes also include some minor code cleanup.

**Leaderboard and Standings Data Transformation**

- Replaced the old `transformGamesToSchoolRank` function with two new, more specific functions:
  - `transformSchoolsData` for processing leaderboard data at the school level, now imported and used in `leaderboards.tsx` [[1]](diffhunk://#diff-704186f571ef288fc26f091740578ec4bf1c513bc037816b913f74d2a3e5a63aL7-R7) [[2]](diffhunk://#diff-704186f571ef288fc26f091740578ec4bf1c513bc037816b913f74d2a3e5a63aL22-R22) [[3]](diffhunk://#diff-5ec6c4bf295cb8228c506b0588ef7c38fc8af8af198bc76ee1c9d23768329364R1-R111).
  - `transformTeamsData` for processing standings data at the team level, now imported and used in `standings.tsx` [[1]](diffhunk://#diff-dabf241d6e81f7d0a6d01300681f9210983d80b27dd343d232eb82209768ca98L18-R23) [[2]](diffhunk://#diff-dabf241d6e81f7d0a6d01300681f9210983d80b27dd343d232eb82209768ca98L124-R124) [[3]](diffhunk://#diff-6519fd6749699902fa36a32ec99ac0eac198bcf0254d5be57295b84c0857f7d7L4-R4).

**File Organization and Naming**

- Renamed `src/components/leaderboards/transformData.tsx` to `src/components/standings/transformTeamsData.ts` to better reflect its usage and responsibility.
- Added a new file `src/components/leaderboards/transformSchoolsData.tsx` to handle school-based leaderboard transformation logic.

**Component Logic Updates**

- Updated the logic in `Leaderboards` and `Standings` components to use the new transformation functions, ensuring that the correct data shape is used for each context [[1]](diffhunk://#diff-704186f571ef288fc26f091740578ec4bf1c513bc037816b913f74d2a3e5a63aL22-R22) [[2]](diffhunk://#diff-dabf241d6e81f7d0a6d01300681f9210983d80b27dd343d232eb82209768ca98L124-R124).
- Commented out the code that added champions without game history in `Standings`, possibly for future revision or removal.

**Minor Code Cleanup**

- Removed unused imports and cleaned up whitespace and formatting in `standings.tsx` for better readability [[1]](diffhunk://#diff-dabf241d6e81f7d0a6d01300681f9210983d80b27dd343d232eb82209768ca98L250-L251) [[2]](diffhunk://#diff-dabf241d6e81f7d0a6d01300681f9210983d80b27dd343d232eb82209768ca98L276) [[3]](diffhunk://#diff-dabf241d6e81f7d0a6d01300681f9210983d80b27dd343d232eb82209768ca98L294-R293).